### PR TITLE
MOBILE-2529: Renaming local file doesn’t change the name section in metadata

### DIFF
--- a/AlfrescoApp/Supporting Files/en.lproj/Localizable.strings
+++ b/AlfrescoApp/Supporting Files/en.lproj/Localizable.strings
@@ -380,6 +380,11 @@
 "document.segment.comments.hasmore.title" = "Comments (%d+)";
 
 /**
+ * Downloads Document Preview Controller
+ */
+"document.segment.repository.metadata.title" = "Repository Metadata";
+
+/**
  * Document Preview Controller
  */
 "document.video.not.supported" = "Playback is not available";

--- a/AlfrescoApp/View Controllers/Document Preview View Controller/DownloadsDocumentPreviewViewController.m
+++ b/AlfrescoApp/View Controllers/Document Preview View Controller/DownloadsDocumentPreviewViewController.m
@@ -37,7 +37,7 @@
     
     [self.pagingSegmentControl removeAllSegments];
     [self.pagingSegmentControl insertSegmentWithTitle:NSLocalizedString(@"document.segment.preview.title", @"Preview Segment Title") atIndex:PagingScrollViewSegmentTypeFilePreview animated:NO];
-    [self.pagingSegmentControl insertSegmentWithTitle:NSLocalizedString(@"document.segment.metadata.title", @"Metadata Segment Title") atIndex:PagingScrollViewSegmentTypeMetadata animated:NO];
+    [self.pagingSegmentControl insertSegmentWithTitle:NSLocalizedString(@"document.segment.repository.metadata.title", @"Metadata Segment Title") atIndex:PagingScrollViewSegmentTypeMetadata animated:NO];
     
     if (!self.document)
     {
@@ -56,7 +56,7 @@
 - (void)localiseUI
 {
     [self.pagingSegmentControl setTitle:NSLocalizedString(@"document.segment.preview.title", @"Preview Segment Title") forSegmentAtIndex:PagingScrollViewSegmentTypeFilePreview];
-    [self.pagingSegmentControl setTitle:NSLocalizedString(@"document.segment.metadata.title", @"Metadata Segment Title") forSegmentAtIndex:PagingScrollViewSegmentTypeMetadata];
+    [self.pagingSegmentControl setTitle:NSLocalizedString(@"document.segment.repository.metadata.title", @"Metadata Segment Title") forSegmentAtIndex:PagingScrollViewSegmentTypeMetadata];
 }
 
 - (void)setupPagingScrollView

--- a/AlfrescoApp/View Controllers/Metadata View Controller/MetaDataViewController.m
+++ b/AlfrescoApp/View Controllers/Metadata View Controller/MetaDataViewController.m
@@ -258,6 +258,10 @@ static NSString * kCMISVersionLabel = @"cmis:versionLabel";
                 
                 metadataCell.propertyValueLabel.text = labelText;
             }
+            else
+            {
+                metadataCell.propertyValueLabel.text = [currentPropertyValue stringValue];
+            }
         }
     }
     


### PR DESCRIPTION
Renamed the "Metadata" tab to "Repository Metadata" to signify what the information represents. Also fixed an unreported issue where properties with a long datatype would not get rendered.
