### PR TITLE
Fixed some type values for defaults in UserPreferences.plist

### DIFF
--- a/AlfrescoApp/Model/Managers/PreferenceManager.m
+++ b/AlfrescoApp/Model/Managers/PreferenceManager.m
@@ -90,7 +90,9 @@ static NSString * const kPreferenceKey = @"kAlfrescoPreferencesKey";
         {
             NSString *preferenceIdentifier = cellInfo[kSettingsCellPreferenceIdentifier];
             
-            if (!self.preferences[preferenceIdentifier])
+            // Check for missing preferences, or preferences of the wrong type
+            if (self.preferences[preferenceIdentifier] == nil ||
+                ![self.preferences[preferenceIdentifier] isKindOfClass:[cellInfo[kSettingsCellDefaultValue] class]])
             {
                 // Set the default value
                 self.preferences[preferenceIdentifier] = cellInfo[kSettingsCellDefaultValue];

--- a/AlfrescoApp/Supporting Files/UserPreferences.plist
+++ b/AlfrescoApp/Supporting Files/UserPreferences.plist
@@ -17,7 +17,7 @@
 					<key>Type</key>
 					<string>AlfrescoSettingsLabel</string>
 					<key>DefaultValue</key>
-					<string>NO</string>
+					<false/>
 					<key>LocalizedCellTitleKey</key>
 					<string>about.title</string>
 				</dict>
@@ -74,7 +74,7 @@
 					<key>Type</key>
 					<string>AlfrescoSettingsToggle</string>
 					<key>DefaultValue</key>
-					<string>NO</string>
+					<false/>
 					<key>LocalizedCellTitleKey</key>
 					<string>settings.security.file.protection</string>
 				</dict>

--- a/AlfrescoApp/View Controllers/Settings View Controller/SettingsViewController.m
+++ b/AlfrescoApp/View Controllers/Settings View Controller/SettingsViewController.m
@@ -53,17 +53,22 @@ static NSUInteger const kCellLeftInset = 10;
     [super viewDidLoad];
     
     self.allowsPullToRefresh = NO;
-	
-    NSString *pListPath = [[NSBundle mainBundle] pathForResource:@"UserPreferences" ofType:@"plist"];
-    NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfFile:pListPath];
-
-    self.tableViewData = [self filteredPreferences:[dictionary objectForKey:kSettingsTableViewData]];
-    self.title = NSLocalizedString([dictionary objectForKey:kSettingsLocalizedTitleKey], @"Settings Title") ;
     
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                 target:self
                                                                                 action:@selector(doneButtonPressed:)];
     self.navigationItem.rightBarButtonItem = doneButton;
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+
+    NSString *pListPath = [[NSBundle mainBundle] pathForResource:@"UserPreferences" ofType:@"plist"];
+    NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfFile:pListPath];
+
+    self.title = NSLocalizedString([dictionary objectForKey:kSettingsLocalizedTitleKey], @"Settings Title") ;
+    self.tableViewData = [self filteredPreferences:[dictionary objectForKey:kSettingsTableViewData]];
 }
 
 #pragma mark - Private Functions


### PR DESCRIPTION
Ensured saved preferences are of the correct type and rest to default value if not (prevents crash in SettingToggleCell)
Ensured preferences are reloaded on the iPad when the view is shown
