### PR TITLE
Fixes for Mobile-3081 and Mobile-3093

### DIFF
--- a/AlfrescoApp/View Controllers/Comments View Controller/CommentViewController.h
+++ b/AlfrescoApp/View Controllers/Comments View Controller/CommentViewController.h
@@ -32,6 +32,6 @@
 @property (nonatomic, weak, readonly) id<CommentViewControllerDelegate> delegate;
 
 - (id)initWithAlfrescoNode:(AlfrescoNode *)node permissions:(AlfrescoPermissions *)permissions session:(id<AlfrescoSession>)session delegate:(id<CommentViewControllerDelegate>)delegate;
-- (void)focusCommentEntry;
+- (void)focusCommentEntry:(BOOL)shouldFocus;
 
 @end

--- a/AlfrescoApp/View Controllers/Comments View Controller/CommentViewController.m
+++ b/AlfrescoApp/View Controllers/Comments View Controller/CommentViewController.m
@@ -191,9 +191,16 @@ static CGFloat const kMaxCommentTextViewHeight = 100.0f;
 
 #pragma mark - Public Functions
 
-- (void)focusCommentEntry
+- (void)focusCommentEntry:(BOOL)shouldFocus
 {
-    [self.addCommentTextView becomeFirstResponder];
+    if(shouldFocus)
+    {
+        [self.addCommentTextView becomeFirstResponder];
+    }
+    else if([self.addCommentTextView isFirstResponder])
+    {
+        [self.addCommentTextView resignFirstResponder];
+    }
 }
 
 #pragma mark - Table view data source

--- a/AlfrescoApp/View Controllers/Document Preview View Controller/BaseDocumentPreviewViewController.m
+++ b/AlfrescoApp/View Controllers/Document Preview View Controller/BaseDocumentPreviewViewController.m
@@ -83,7 +83,7 @@
     PagingScrollViewSegmentType selectedSegment = self.pagingSegmentControl.selectedSegmentIndex;
     [self.pagingScrollView scrollToDisplayViewAtIndex:selectedSegment animated:YES];
     
-    if(selectedSegment != PagingScrollViewSegmentTypeComments)
+    if((selectedSegment != PagingScrollViewSegmentTypeComments) && ([self isKindOfClass:[DocumentPreviewViewController class]]))
     {
         [self shouldFocusComments:NO];
     }

--- a/AlfrescoApp/View Controllers/Document Preview View Controller/BaseDocumentPreviewViewController.m
+++ b/AlfrescoApp/View Controllers/Document Preview View Controller/BaseDocumentPreviewViewController.m
@@ -82,6 +82,17 @@
 {
     PagingScrollViewSegmentType selectedSegment = self.pagingSegmentControl.selectedSegmentIndex;
     [self.pagingScrollView scrollToDisplayViewAtIndex:selectedSegment animated:YES];
+    
+    if(selectedSegment != PagingScrollViewSegmentTypeComments)
+    {
+        [self shouldFocusComments:NO];
+    }
+}
+
+#pragma mark - Private methods
+- (void) shouldFocusComments:(BOOL)shouldFocusComments
+{
+    AlfrescoLogError(@"You need to implement %@", _cmd);
 }
 
 #pragma mark - ActionCollectionViewDelegate Functions

--- a/AlfrescoApp/View Controllers/Document Preview View Controller/BaseDocumentPreviewViewController.xib
+++ b/AlfrescoApp/View Controllers/Document Preview View Controller/BaseDocumentPreviewViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BaseDocumentPreviewViewController">

--- a/AlfrescoApp/View Controllers/Document Preview View Controller/DocumentPreviewViewController.m
+++ b/AlfrescoApp/View Controllers/Document Preview View Controller/DocumentPreviewViewController.m
@@ -281,6 +281,12 @@ static CGFloat const kActionViewAdditionalTextRowHeight = 15.0f;
     }
 }
 
+- (void) shouldFocusComments:(BOOL)shouldFocusComments
+{
+    CommentViewController *commentsViewController = [self.pagingControllers objectAtIndex:PagingScrollViewSegmentTypeComments];
+    [commentsViewController focusCommentEntry:shouldFocusComments];
+}
+
 #pragma mark - Document Editing Notification
 
 - (void)editingDocumentCompleted:(NSNotification *)notification
@@ -292,6 +298,7 @@ static CGFloat const kActionViewAdditionalTextRowHeight = 15.0f;
 
 - (void)didPressActionItem:(ActionCollectionItem *)actionItem cell:(UICollectionViewCell *)cell inView:(UICollectionView *)view
 {
+    BOOL shouldFocusComments = NO;
     if ([actionItem.itemIdentifier isEqualToString:kActionCollectionIdentifierLike])
     {
         [self.actionHandler pressedLikeActionItem:actionItem];
@@ -320,8 +327,7 @@ static CGFloat const kActionViewAdditionalTextRowHeight = 15.0f;
     {
         self.pagingSegmentControl.selectedSegmentIndex = PagingScrollViewSegmentTypeComments;
         [self.pagingScrollView scrollToDisplayViewAtIndex:PagingScrollViewSegmentTypeComments animated:YES];
-        CommentViewController *commentsViewController = [self.pagingControllers objectAtIndex:PagingScrollViewSegmentTypeComments];
-        [commentsViewController focusCommentEntry];
+        shouldFocusComments = YES;
     }
     else if ([actionItem.itemIdentifier isEqualToString:kActionCollectionIdentifierPrint])
     {
@@ -351,6 +357,8 @@ static CGFloat const kActionViewAdditionalTextRowHeight = 15.0f;
     {
         [self.actionHandler pressedUploadNewVersion:actionItem node:self.document];
     }
+    
+    [self shouldFocusComments:shouldFocusComments];
 }
 
 #pragma mark - ActionViewHandlerDelegate Functions

--- a/AlfrescoApp/View Controllers/Document Preview View Controller/DownloadsDocumentPreviewViewController.m
+++ b/AlfrescoApp/View Controllers/Document Preview View Controller/DownloadsDocumentPreviewViewController.m
@@ -92,16 +92,9 @@
 - (void)setupPagingScrollView
 {
     [self.pagingSegmentControl removeAllSegments];
-    if (IS_IPAD)
-    {
-        [self.pagingSegmentControl insertSegmentWithTitle:NSLocalizedString(@"document.segment.preview.title", @"Preview Segment Title") atIndex:PagingScrollViewSegmentTypeFilePreview animated:NO];
-    }
-    else
-    {
-        [self.pagingSegmentControl insertSegmentWithImage:[UIImage imageNamed:@"segment-icon-preview.png"] atIndex:PagingScrollViewSegmentTypeFilePreview animated:NO];
-    }
 
-    [self.pagingSegmentControl insertSegmentWithTitle:NSLocalizedString(@"document.segment.repository.metadata.title", @"Metadata Segment Title") atIndex:PagingScrollViewSegmentTypeMetadata animated:NO];
+    [self.pagingSegmentControl insertSegmentWithImage:[UIImage imageNamed:@"segment-icon-preview.png"] atIndex:PagingScrollViewSegmentTypeFilePreview animated:NO];
+    [self.pagingSegmentControl insertSegmentWithImage:[UIImage imageNamed:@"segment-icon-properties.png"] atIndex:PagingScrollViewSegmentTypeMetadata animated:NO];
     
     FilePreviewViewController *filePreviewController = [[FilePreviewViewController alloc] initWithFilePath:self.documentContentFilePath document:self.document];
     [self.pagingControllers insertObject:filePreviewController atIndex:PagingScrollViewSegmentTypeFilePreview];

--- a/AlfrescoApp/View Controllers/Folder Preview View Controller/FolderPreviewViewController.m
+++ b/AlfrescoApp/View Controllers/Folder Preview View Controller/FolderPreviewViewController.m
@@ -275,18 +275,30 @@ typedef NS_ENUM(NSUInteger, PagingScrollViewSegmentFolderType)
     }
 }
 
+- (void) shouldFocusComments:(BOOL)shouldFocusComments
+{
+    CommentViewController *commentsViewController = [self.pagingControllers objectAtIndex:PagingScrollViewSegmentFolderTypeComments];
+    [commentsViewController focusCommentEntry:shouldFocusComments];
+}
+
 #pragma mark - IBActions
 
 - (IBAction)segmentValueChanged:(id)sender
 {
     PagingScrollViewSegmentFolderType selectedSegment = self.segmentControl.selectedSegmentIndex;
     [self.pagedScrollView scrollToDisplayViewAtIndex:selectedSegment animated:YES];
+    
+    if(selectedSegment != PagingScrollViewSegmentFolderTypeComments)
+    {
+        [self shouldFocusComments:NO];
+    }
 }
 
 #pragma mark - ActionCollectionViewDelegate Functions
 
 - (void)didPressActionItem:(ActionCollectionItem *)actionItem cell:(UICollectionViewCell *)cell inView:(UICollectionView *)view
 {
+    BOOL shouldFocusComments = NO;
     if ([actionItem.itemIdentifier isEqualToString:kActionCollectionIdentifierLike])
     {
         [self.actionHandler pressedLikeActionItem:actionItem];
@@ -307,8 +319,7 @@ typedef NS_ENUM(NSUInteger, PagingScrollViewSegmentFolderType)
     {
         self.segmentControl.selectedSegmentIndex = PagingScrollViewSegmentFolderTypeComments;
         [self.pagedScrollView scrollToDisplayViewAtIndex:PagingScrollViewSegmentFolderTypeComments animated:YES];
-        CommentViewController *commentsViewController = [self.pagingControllers objectAtIndex:PagingScrollViewSegmentFolderTypeComments];
-        [commentsViewController focusCommentEntry];
+        shouldFocusComments = YES;
     }
     else if ([actionItem.itemIdentifier isEqualToString:kActionCollectionIdentifierDelete])
     {
@@ -322,6 +333,8 @@ typedef NS_ENUM(NSUInteger, PagingScrollViewSegmentFolderType)
     {
         [self.actionHandler pressedUploadActionItem:actionItem presentFromView:cell inView:view];
     }
+    
+    [self shouldFocusComments:shouldFocusComments];
 }
 
 #pragma mark - CommentsViewControllerDelegate Functions


### PR DESCRIPTION
Added fixes for Mobile-3081 and Mobile-3093

Mobile-3081:
- added functionality to resign first responder when a new page in the scroll view is presented

Mobile-3093:
- removed some redundant code
- added the correct icon to the segmented control item