### PR TITLE
IOS-715 & IOS-712

### DIFF
--- a/AlfrescoApp/Model/Managers/RealmSyncManager+Internal.h
+++ b/AlfrescoApp/Model/Managers/RealmSyncManager+Internal.h
@@ -37,6 +37,7 @@
 @property (nonatomic, strong) NSMutableArray *nodesToUpload;
 
 @property (nonatomic) BOOL lastConnectivityFlag;
+@property (nonatomic) BOOL disableSyncInProgress;
 
 - (SyncOperationQueue *)currentOperationQueue;
 


### PR DESCRIPTION
IOS-715: Automatically save conflict files to local files when manual…ly disabling sync;
IOS-712: Sync files with conflict errors doesn't get saved locally when hiding "Synced Content" menu