### PR TITLE
IOS-927 and IOS-928

### DIFF
--- a/AlfrescoDocumentPickerFileProvider/Info.plist
+++ b/AlfrescoDocumentPickerFileProvider/Info.plist
@@ -22,6 +22,11 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>dev</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionFileProviderDocumentGroup</key>


### PR DESCRIPTION
…928: Cannot open files from Word on iOS 9.3.x (Added ATS key to File Provider info.plist)