### PR TITLE
MOBILEAPPS-225 [ACS] Incorrect URL is used for basic auth when an AIM…

### DIFF
--- a/AlfrescoApp/View Controllers/Accounts View Controllers/New Account/AccountDetailsViewController.m
+++ b/AlfrescoApp/View Controllers/Accounts View Controllers/New Account/AccountDetailsViewController.m
@@ -168,6 +168,7 @@
                 
             case AccountDataSourceTypeNewAccountCredentials:
                 self.formBackupAccount = account;
+                self.formBackupAccount.accountType = UserAccountTypeOnPremise;
                 self.account = [[UserAccount alloc] initWithAccountType:UserAccountTypeOnPremise];
                 break;
             case AccountDataSourceTypeNewAccountAIMS:


### PR DESCRIPTION
…S flow was done in front